### PR TITLE
Add S3 Client

### DIFF
--- a/const.py
+++ b/const.py
@@ -1,4 +1,9 @@
+import os
 from typing import Literal
+
+from dotenv import load_dotenv
+
+load_dotenv()
 
 DEBUG: bool = True
 
@@ -7,3 +12,8 @@ DEFAULT_IMAGE_QUALITY: Literal["standard", "hd"] = "standard"
 DEFAULT_IMAGE_SIZE: (
     Literal["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"] | None
 ) = "1024x1024"
+
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+AWS_S3_BUCKET = os.getenv("AWS_S3_BUCKET")
+AWS_REGION = os.getenv("AWS_REGION")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ alembic==1.14.0
 annotated-types==0.7.0
 anyio==4.6.2.post1
 blinker==1.9.0
+boto3==1.35.71
+botocore==1.35.71
 certifi==2024.8.30
 click==8.1.7
 distro==1.9.0
@@ -15,6 +17,7 @@ iniconfig==2.0.0
 itsdangerous==2.2.0
 Jinja2==3.1.4
 jiter==0.7.1
+jmespath==1.0.1
 Mako==1.3.6
 MarkupSafe==3.0.2
 openai==1.55.1
@@ -25,9 +28,13 @@ pydantic==2.10.1
 pydantic_core==2.27.1
 pytest==8.3.3
 pytest-mock==3.14.0
+python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
+s3transfer==0.10.4
+six==1.16.0
 sniffio==1.3.1
 SQLAlchemy==2.0.36
 tqdm==4.67.1
 typing_extensions==4.12.2
+urllib3==2.2.3
 Werkzeug==3.1.3

--- a/server/s3_client.py
+++ b/server/s3_client.py
@@ -1,0 +1,59 @@
+""" 
+S3 Singleton Factory
+
+Keeps overhead low by keeping at most one S3 client alive, refreshing
+the client if credentials are invalid or expire.
+
+Get client when needed; don't hold onto it too long or we won't be able 
+to guarantee a valid connection.
+ """
+
+import boto3  # type: ignore
+from botocore.exceptions import (  # type: ignore
+    NoCredentialsError,
+    PartialCredentialsError,
+    ClientError,
+)
+
+from const import (
+    AWS_ACCESS_KEY_ID,
+    AWS_REGION,
+    AWS_SECRET_ACCESS_KEY,
+)
+
+_s3_client = None
+
+
+def _create_s3_client():
+    return boto3.client(
+        "s3",
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        region_name=AWS_REGION,
+    )
+
+
+def is_s3_session_valid():
+    global _s3_client
+    try:
+        _s3_client.list_buckets()
+        return True
+    except (NoCredentialsError, PartialCredentialsError):
+        print("Invalid or missing credentials.")
+        return False
+    except ClientError as e:
+        error_code = e.response["Error"]["Code"]
+        if error_code in ["ExpiredToken", "InvalidToken"]:
+            print("Session credentials are expired or invalid.")
+            return False
+        print(f"An unexpected error occurred: {e}")
+        return False
+
+
+def get_s3_client():
+    global _s3_client
+
+    if _s3_client is None or not is_s3_session_valid():
+        _s3_client = _create_s3_client()
+
+    return _s3_client


### PR DESCRIPTION
## Type of Change

- [ ] Debugging
- [x] New Feature
- [ ] Refactor/File Clean-up

## Describe changes
Adds a singleton s3 client factory. By initializing the client only when needed, we reduce overhead. We test if the client credentials are still valid on every get, but we can't guarantee how long it will remain valid for so all operations that use this should get the client only when they're about to use it.

To use, create an S3 bucket, an IAM user with the AmazonS3FullAccess policy and generate an access key. Add as environmental variables of the following names.

AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_S3_BUCKET
AWS_REGION

## Checklist

- [ ] I have made RSpec test  
- [ ] My code is passing all tests 
- [x] I assigned a review for my PR